### PR TITLE
feat(RouterConnector): add replacePath method

### DIFF
--- a/src/common/RouterConnector.js
+++ b/src/common/RouterConnector.js
@@ -3,6 +3,7 @@ import { propTypes as routerTypes } from "react-router"
 import { connect } from "react-redux"
 
 export const SET_PATH = "router/SET_PATH"
+export const REPLACE_PATH = "router/REPLACE_PATH"
 export const RECOVER_PATH = "/pingback/"
 
 const initialState = {
@@ -18,8 +19,9 @@ const initialState = {
 export function routerReducer(state = initialState, action) {
   switch (action.type) {
     case SET_PATH:
-      return { ...state, path: action.path }
-
+      return { ...state, path: action.path, replace: false }
+    case REPLACE_PATH:
+      return { ...state, path: action.path, replace: true }
     default:
       return state
   }
@@ -37,8 +39,16 @@ export function setPath(path) {
 }
 
 /**
- *
+ * [replacePath description]
+ * @param {[type]} path [description]
  */
+export function replacePath(path) {
+  return {
+    type: REPLACE_PATH,
+    path
+  }
+}
+
 class RoutingConnector extends React.Component {
   componentDidMount() {
     this.context.history.listen(({ pathname }) => {
@@ -60,7 +70,11 @@ class RoutingConnector extends React.Component {
         // Will receive props means they are not yet set, so we have to wait
         // a little before updating the history. Otherwise stuff breaks.
         setTimeout(() => {
-          this.context.history.push(nextProps.path)
+          if (nextProps.replace === true) {
+            this.context.history.replace(nextProps.path)
+          } else {
+            this.context.history.push(nextProps.path)
+          }
         }, 0)
       }
     }
@@ -88,7 +102,8 @@ RoutingConnector.contextTypes = {
 
 function mapStateToProps(state) {
   return {
-    path: state.router.path
+    path: state.router.path,
+    replace: state.router.replace
   }
 }
 


### PR DESCRIPTION
Offered a method to replace history instead of generating new history item. It is useful on tab switch.