### PR TITLE
Remove absolute path from build/main.js

### DIFF
--- a/src/server/config.js
+++ b/src/server/config.js
@@ -4,25 +4,29 @@
 // These config values then become a part of the server bundle.
 
 import { resolve } from "path"
+import appRootDir from "app-root-dir"
+
+const APP_ROOT = appRootDir.get()
 
 export const ABSOLUTE_CLIENT_OUTPUT_PATH = resolve(
-  process.env.APP_ROOT,
+  APP_ROOT,
   process.env.CLIENT_BUNDLE_OUTPUT_PATH
 )
 
 export const ABSOLUTE_ASSETSINFO_PATH = resolve(
-  process.env.APP_ROOT,
+  APP_ROOT,
   process.env.CLIENT_BUNDLE_OUTPUT_PATH,
   process.env.CLIENT_BUNDLE_ASSETS_FILENAME
 )
 
 export const ABSOLUTE_CHUNKMANIFEST_PATH = resolve(
-  process.env.APP_ROOT,
+  APP_ROOT,
   process.env.CLIENT_BUNDLE_OUTPUT_PATH,
   process.env.CLIENT_BUNDLE_CHUNK_MANIFEST_FILENAME
 )
 
 export const ABSOLUTE_PUBLIC_PATH = resolve(
-  process.env.APP_ROOT,
+  APP_ROOT,
   process.env.CLIENT_PUBLIC_PATH
 )
+

--- a/src/webpack/ConfigFactory.js
+++ b/src/webpack/ConfigFactory.js
@@ -729,8 +729,6 @@ function ConfigFactory({ target, mode, root = CWD, ...options })
         // builds as React relies on process.env.NODE_ENV for optimizations.
         "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
 
-        "process.env.APP_ROOT": JSON.stringify(path.resolve(root)),
-
         // All the below items match the config items in our .env file. Go
         // to the .env.example for a description of each key.
         "process.env.SERVER_PORT": process.env.SERVER_PORT,


### PR DESCRIPTION
Fixes #116. Replaces #120.

The purpose of this PR is to allow CI server to build project in different folder than final production server.

This PR should be tested against already existing projects to see if there is no side effect of this change.

